### PR TITLE
Defer production cost creation to posting

### DIFF
--- a/org.eevolution.manufacturing/src/main/java/base/org/eevolution/manufacturing/acct/Doc_PPCostCollector.java
+++ b/org.eevolution.manufacturing/src/main/java/base/org/eevolution/manufacturing/acct/Doc_PPCostCollector.java
@@ -38,6 +38,7 @@ import org.compiere.model.Query;
 import org.compiere.util.Env;
 import org.compiere.util.Msg;
 import org.eevolution.manufacturing.model.MPPCostCollector;
+import org.eevolution.manufacturing.services.StandardCostCollector;
 import org.eevolution.model.RoutingService;
 import org.eevolution.model.RoutingServiceFactory;
 
@@ -120,13 +121,25 @@ public class Doc_PPCostCollector extends Doc
 	 */
 	public ArrayList<Fact> createFacts (MAcctSchema as)
 	{
-		setC_Currency_ID(as.getC_Currency_ID());
-		final ArrayList<Fact> facts = new ArrayList<Fact>();
-		
-		if(MPPCostCollector.COSTCOLLECTORTYPE_MaterialReceipt.equals(costCollector.getCostCollectorType()))
-			facts.add(createMaterialReceipt(as));
-		else if (MPPCostCollector.COSTCOLLECTORTYPE_ComponentIssue.equals(costCollector.getCostCollectorType()))
-			facts.add(createComponentIssue(as));
+                setC_Currency_ID(as.getC_Currency_ID());
+                final ArrayList<Fact> facts = new ArrayList<Fact>();
+
+                // Generate cost details when accounting
+                if (MPPCostCollector.COSTCOLLECTORTYPE_MethodChangeVariance.equals(costCollector.getCostCollectorType()) && costCollector.isVariance())
+                        StandardCostCollector.createMethodVariances(costCollector);
+                else if (MPPCostCollector.COSTCOLLECTORTYPE_ActivityControl.equals(costCollector.getCostCollectorType()))
+                        StandardCostCollector.createActivityControl(costCollector);
+                else if (MPPCostCollector.COSTCOLLECTORTYPE_UsegeVariance.equals(costCollector.getCostCollectorType()) && costCollector.getPP_Order_BOMLine_ID() > 0)
+                        StandardCostCollector.createUsageVariances(costCollector);
+                else if (MPPCostCollector.COSTCOLLECTORTYPE_UsegeVariance.equals(costCollector.getCostCollectorType()) && costCollector.getPP_Order_Node_ID() > 0)
+                        StandardCostCollector.createActivityControl(costCollector);
+                else if (MPPCostCollector.COSTCOLLECTORTYPE_RateVariance.equals(costCollector.getCostCollectorType()))
+                        StandardCostCollector.createRateVariances(costCollector);
+
+                if(MPPCostCollector.COSTCOLLECTORTYPE_MaterialReceipt.equals(costCollector.getCostCollectorType()))
+                        facts.add(createMaterialReceipt(as));
+                else if (MPPCostCollector.COSTCOLLECTORTYPE_ComponentIssue.equals(costCollector.getCostCollectorType()))
+                        facts.add(createComponentIssue(as));
 		else if (MPPCostCollector.COSTCOLLECTORTYPE_MethodChangeVariance.equals(costCollector.getCostCollectorType()))
 			facts.add(createVariance(as, ProductCost.ACCTTYPE_P_MethodChangeVariance));
 		else if (MPPCostCollector.COSTCOLLECTORTYPE_UsegeVariance.equals(costCollector.getCostCollectorType()))

--- a/org.eevolution.manufacturing/src/main/java/base/org/eevolution/manufacturing/model/MPPCostCollector.java
+++ b/org.eevolution.manufacturing/src/main/java/base/org/eevolution/manufacturing/model/MPPCostCollector.java
@@ -484,9 +484,9 @@ public class MPPCostCollector extends X_PP_Cost_Collector implements DocAction ,
 				orderBomLine.saveEx();
 				log.fine("OrderLine -> Reserved="+orderBomLine.getQtyReserved()+", Delivered="+orderBomLine.getQtyDelivered());
 			} // Creathe meterial Method Change Variance
-			else if (isIssue() && isCostCollectorType(COSTCOLLECTORTYPE_MethodChangeVariance) && isVariance()) {
-				StandardCostCollector.createMethodVariances(this);
-			}
+                        else if (isIssue() && isCostCollectorType(COSTCOLLECTORTYPE_MethodChangeVariance) && isVariance()) {
+                                // Cost details will be generated during accounting
+                        }
 
 			if (isReceipt())
 			{
@@ -551,7 +551,7 @@ public class MPPCostCollector extends X_PP_Cost_Collector implements DocAction ,
 			}
 			else
 			{
-				StandardCostCollector.createActivityControl(this);
+                                // Cost details will be generated during accounting
 				if(activity.getQtyDelivered().compareTo(activity.getQtyRequired()) >= 0)
 				{
 					activity.closeIt();
@@ -569,7 +569,7 @@ public class MPPCostCollector extends X_PP_Cost_Collector implements DocAction ,
 			log.fine("OrderLine - Reserved=" + orderBOMLine.getQtyReserved() + ", Delivered=" + orderBOMLine.getQtyDelivered());
 			orderBOMLine.saveEx();
 			log.fine("OrderLine -> Reserved=" + orderBOMLine.getQtyReserved() + ", Delivered=" + orderBOMLine.getQtyDelivered());
-			StandardCostCollector.createUsageVariances(this);
+                        // Cost details will be generated during accounting
 		}
 		//
 		// Usage Variance (resource)
@@ -579,7 +579,7 @@ public class MPPCostCollector extends X_PP_Cost_Collector implements DocAction ,
 			activity.setDurationReal(activity.getDurationReal().add(getDurationReal()));
 			activity.setSetupTimeReal(activity.getSetupTimeReal().add(getSetupTimeReal()));
 			activity.saveEx();
-			StandardCostCollector.createActivityControl(this);
+                        // Cost details will be generated during accounting
 		}
 		else
 		{


### PR DESCRIPTION
## Summary
- stop creating manufacturing cost details when transactions are recorded
- create cost details during posting in Doc_PPCostCollector instead

## Testing
- `gradle :org.eevolution.manufacturing:build`


------
https://chatgpt.com/codex/tasks/task_e_6896c020ac408321867f1cbd81b894fe